### PR TITLE
@alloy => Obtain user details from APIv2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,18 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1.2
-  - 2.0.0
-  - 1.9.3
-  - rbx-2.2.10
+  - 2.3.0
+  - 2.2
+  - rbx-2
   - jruby-19mode
   - ruby-head
   - jruby-head
 
 matrix:
   allow_failures:
+    - rvm: rbx-2
     - rvm: ruby-head
     - rvm: jruby-head
+
+before_install:
+  - gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.2.0 (Next)
+============
+
+* [#5](https://github.com/artsy/omniauth-artsy/pull/5): Obtain user details from APIv2 upon login - [@dblock](https://github.com/dblock).
+
 0.1.1 (5/4/2016)
 ================
 

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Artsy
-    VERSION = '0.1.1'
+    VERSION = '0.2.0'
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -21,7 +21,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/api/v1/me', headers: { 'X-ACCESS-TOKEN' => access_token.token }).parsed
+        @raw_info ||= access_token.get('/api/current_user', headers: { 'X-ACCESS-TOKEN' => access_token.token }).parsed
       end
     end
   end

--- a/spec/omniauth/strategies/artsy_spec.rb
+++ b/spec/omniauth/strategies/artsy_spec.rb
@@ -40,7 +40,7 @@ describe OmniAuth::Strategies::Artsy do
     allow(subject).to receive(:access_token).and_return(access_token)
 
     response = instance_double(OAuth2::Response, parsed: @raw_info_hash)
-    expect(access_token).to receive(:get).with('/api/v1/me', headers: { 'X-ACCESS-TOKEN' => 'secret' }).and_return(response)
+    expect(access_token).to receive(:get).with('/api/current_user', headers: { 'X-ACCESS-TOKEN' => 'secret' }).and_return(response)
 
     expect(subject.raw_info).to eq(@raw_info_hash)
   end


### PR DESCRIPTION
If you create an app in http://developers.artsy.net, it will make it so that you can only use APIv2. If you try to do omniauth with such app, it will succeed at login, but will fail to retrieve the user information and cause an error. I found this by trying to run [doppler](https://github.com/artsy/doppler) per its instructions.

The solution is to use APIv2 as well, which gives less details (just your name and ID, not email), but it's good enough for now. We can easily extend this to get more information if needed.

Note that v1 app tokens work with both v1 and v2, but v2 tokens only work with v2.