### PR TITLE
Fix configure issue

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,7 +9,7 @@
 # Offense count: 2
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 64
+  Max: 67
 
 # Offense count: 8
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-0.2.2 (Next)
+0.2.3 (Next)
 ============
 
 * Your contribution here.
+
+0.2.2
+============
+
+* [#7](https://github.com/artsy/omniauth-artsy/pull/7): Fix issue in configuring Artsy's strategy when using new config - [@ashkan18](https://github.com/ashkan18).
 
 0.2.1
 ============

--- a/lib/omniauth-artsy/config.rb
+++ b/lib/omniauth-artsy/config.rb
@@ -14,7 +14,15 @@ module OmniAuth
 
     class << self
       def configure
-        block_given? ? yield(Config) : Config
+        if block_given?
+          yield(Config)
+          reconfigure_strategy
+        end
+        Config
+      end
+
+      def reconfigure_strategy
+        Strategies::Artsy.configure
       end
 
       def config

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Artsy
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.2'.freeze
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -3,10 +3,14 @@ require 'omniauth-oauth2'
 module OmniAuth
   module Strategies
     class Artsy < OmniAuth::Strategies::OAuth2
-      option :client_options,
-             site: OmniAuth::Artsy.config.artsy_api_url || ENV['ARTSY_API_URL'] || ENV['gravity_url'],
-             authorize_url: '/oauth2/authorize?scope=offline_access&response_type=code',
-             token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code'
+      def self.configure
+        option :client_options,
+               site: OmniAuth::Artsy.config.artsy_api_url || ENV['ARTSY_API_URL'] || ENV['gravity_url'],
+               authorize_url: '/oauth2/authorize?scope=offline_access&response_type=code',
+               token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code'
+      end
+
+      configure
 
       def request_phase
         super

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe OmniAuth::Artsy::Config do
   describe '#configure' do
     before do
+      expect(OmniAuth::Artsy).to receive(:reconfigure_strategy).once
       OmniAuth::Artsy.configure do |config|
         config.artsy_api_url = 'http://localhost:3000/api'
       end

--- a/spec/omniauth/strategies/artsy_spec.rb
+++ b/spec/omniauth/strategies/artsy_spec.rb
@@ -22,8 +22,11 @@ describe OmniAuth::Strategies::Artsy do
   end
 
   describe '#client_options' do
-    it 'returns nil for Artsy API URL without setting' do
-      expect(subject.options.client_options.site).to be_nil
+    it 'returns correct url for Artsy API URL when it was set' do
+      OmniAuth::Artsy.configure do |config|
+        config.artsy_api_url = 'http://api.test.url'
+      end
+      expect(subject.options.client_options.site).to eq 'http://api.test.url'
     end
 
     it 'has correct authorize url' do


### PR DESCRIPTION
# Problem
Configuring `artsy_api_url` in `OmniAuth::Artsy` doesn't change `site` in `OmniAuth::Strategies::Artsy`.

# Solution
This is because of the fact that `option` method in `Strategies::Artsy` was called at load time and when we configure `OmniAuth::Artsy` it's too late and doesn't impact how strategy was setup. Not sure what's the best solution here, but I ended up:
1) Move `option` call in `OmniAuth::Strategies::Artsy` to `configure` method and call it once during load time for existing users of this gem.
2) Add `reconfigure_strategy` method to `OmniAuth::Artsy` which will be called after running `configure` block and will call `configure` method mentioned ☝️ 
