### PR TITLE
Test against latest Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,18 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.6.0
+  - 2.5.3
+  - 2.4.4
   - 2.3.0
-  - 2.2
-  - rbx-2
-  - jruby-19mode
+  - jruby-9.2.5.0
   - ruby-head
   - jruby-head
 
 matrix:
   allow_failures:
-    - rvm: rbx-2
     - rvm: ruby-head
+    - rvm: jruby-9.2.5.0
     - rvm: jruby-head
 
 before_install:


### PR DESCRIPTION
 * Removes Rubinius
 * Adds Ruby 2.6.0, 2.5.3, and 2.4.4
 * Replaces `jruby-19mode` with `jruby-9.2.5.0` since at this point `jruby-9.2.5.0` is old enough