### PR TITLE
chore: Allow GET requests from omniauth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.6.0
   - 2.5.3
   - 2.4.4
-  - 2.3.0
   - jruby-9.2.5.0
   - ruby-head
   - jruby-head

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Artsy
-    VERSION = '0.2.3'
+    VERSION = '0.3.3'
   end
 end

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Artsy
-    VERSION = '0.3.3'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -10,6 +10,12 @@ module OmniAuth
                site: OmniAuth::Artsy.config.artsy_api_url || ENV['ARTSY_API_URL'] || ENV['gravity_url'],
                authorize_url: '/oauth2/authorize?scope=offline_access&response_type=code',
                token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code'
+        # TODO: Allow GET requests to redirect to /auth/artsy for now, which exposes us
+        # to CSRF attacks. We'll want to change the auth redirect behavior to a POST
+        # request at some point in the future.
+        # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
+        OmniAuth.config.allowed_request_methods = %i[post get]
+        OmniAuth.config.silence_get_warning = true
       end
 
       configure

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -14,8 +14,8 @@ module OmniAuth
         # to CSRF attacks. We'll want to change the auth redirect behavior to a POST
         # request at some point in the future.
         # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-        OmniAuth.config.allowed_request_methods = %i[post get]
-        OmniAuth.config.silence_get_warning = true
+        OmniAuth.config.allowed_request_methods = %i[post get] if OmniAuth.config.respond_to?(:allowed_request_methods=)
+        OmniAuth.config.silence_get_warning = true if OmniAuth.config.respond_to?(:silence_get_warning=)
       end
 
       configure

--- a/omniauth-artsy.gemspec
+++ b/omniauth-artsy.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Omniauth plugin for Artsy authentication.'
   spec.homepage = 'https://github.com/artsy/omniauth-artsy'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = spec.homepage


### PR DESCRIPTION
So this works! I removed the lines from volt's `initializers/omniauth.rb` file and stuck them in here. 

I think next steps would be to upgrade this gem in kinetic and artsy-auth, then upgrade those gems in affected repos.