### PR TITLE
Pass original_session_id to oauth provider if available (PLATFORM-2978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
+
+
 0.2.3 (Next)
 ===========
 
 * Your contribution here.
+
+0.3.1
+============
+* [#15](https://github.com/artsy/omniauth-artsy/pull/15): pass an original_session_id to oauth provider if available - [@joeyAghion](https://github.com/joeyAghion)
+
+0.3.0
+============
+* [#14](https://github.com/artsy/omniauth-artsy/pull/14): permit GET requests globally, allowing omniauth upgrades - [@ansor4](https://github.com/ansor4).
 
 0.2.3
 ============

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Artsy
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -31,6 +31,16 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/api/current_user', headers: { 'X-ACCESS-TOKEN' => access_token.token }).parsed
       end
+
+      alias old_request_phase request_phase
+
+      def request_phase
+        if session.id && !session.id.empty?
+          options[:authorize_params] ||= {}
+          options[:authorize_params].merge!(original_session_id: session.id)
+        end
+        old_request_phase
+      end
     end
   end
 end


### PR DESCRIPTION
We'd like the API to be able to associate users' original sessions with backend account activity. This PR introduces support for an optional `original_session_id` parameter to certain authentication actions. Backend support is being added in https://github.com/artsy/gravity/pull/13895.

(This deserves a test but I couldn't get one to work after struggling for 1+ hours, so submitting this anyway.)

https://artsyproduct.atlassian.net/browse/PLATFORM-2978