### PR TITLE
Disallow GET requests for omniauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,17 @@
-0.2.3 (Next)
+0.4.1 (Next)
 ===========
 
 * Your contribution here.
+
+0.4.0
+============
+
+* [#16](https://github.com/artsy/omniauth-artsy/pull/16): Disallow GET requests for omniauth - [@starsirius](https://github.com/starsirius).
+
+0.3.0
+============
+
+* [#14](https://github.com/artsy/omniauth-artsy/pull/14): Allow GET requests for omniauth - [@ansor4](https://github.com/ansor4).
 
 0.2.3
 ============

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Artsy
-    VERSION = '0.3.0'
+    VERSION = '0.4.0'
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -10,12 +10,6 @@ module OmniAuth
                site: OmniAuth::Artsy.config.artsy_api_url || ENV['ARTSY_API_URL'] || ENV['gravity_url'],
                authorize_url: '/oauth2/authorize?scope=offline_access&response_type=code',
                token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code'
-        # TODO: Allow GET requests to redirect to /auth/artsy for now, which exposes us
-        # to CSRF attacks. We'll want to change the auth redirect behavior to a POST
-        # request at some point in the future.
-        # https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284
-        OmniAuth.config.allowed_request_methods = %i[post get] if OmniAuth.config.respond_to?(:allowed_request_methods=)
-        OmniAuth.config.silence_get_warning = true if OmniAuth.config.respond_to?(:silence_get_warning=)
       end
 
       configure


### PR DESCRIPTION
In https://github.com/artsy/artsy-auth/pull/9, I'm working on a proper mitigation for CVE-2015-9284. [The spec](https://github.com/artsy/artsy-auth/pull/9/files#diff-26daabe97ab6f35a45ce12af27688b296554351cb05bf09e3bf86dd9dde02fc9R7-R13) is failing because we allow `GET` requests in https://github.com/artsy/omniauth-artsy/pull/14 as a workaround.

I want to cut a new version with `GET` requests disabled. With that version, clients need to mitigate CVE-2015-9284 themselves, hopefully through updating artsy-auth or kinetic.