### PR TITLE
fix: tolerate oauth2's v2 by specifying auth_scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
-0.4.1 (Next)
+(Next)
 ===========
 
 * Your contribution here.
+
+0.5.0
+===========
+
+* [#17](https://github.com/artsy/omniauth-artsy/pull/17): specify auth_scheme for compatibility with oauth2 >=2 - [@joeyAghion](https://github.com/joeyAghion).
 
 0.4.0
 ============

--- a/lib/omniauth-artsy/version.rb
+++ b/lib/omniauth-artsy/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module Artsy
-    VERSION = '0.4.0'
+    VERSION = '0.5.0'
   end
 end

--- a/lib/omniauth/strategies/artsy.rb
+++ b/lib/omniauth/strategies/artsy.rb
@@ -9,7 +9,8 @@ module OmniAuth
         option :client_options,
                site: OmniAuth::Artsy.config.artsy_api_url || ENV['ARTSY_API_URL'] || ENV['gravity_url'],
                authorize_url: '/oauth2/authorize?scope=offline_access&response_type=code',
-               token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code'
+               token_url: '/oauth2/access_token?scope=offline_access&response_type=code&grant_type=authorization_code',
+               auth_scheme: :request_body
       end
 
       configure


### PR DESCRIPTION
This makes omniauth-artsy compatible with `oauth2` >=2. From https://gitlab.com/oauth-xx/oauth2/-/merge_requests/312:
> [#312](https://gitlab.com/oauth-xx/oauth2/-/merge_requests/312) - BREAKING: Set :basic_auth as default for :auth_scheme instead of :request_body. This was default behavior before 1.3.0. ([@tetsuya](https://github.com/tetsuya), [@wy193777](https://github.com/wy193777))